### PR TITLE
Fix key path

### DIFF
--- a/lib/rsa.js
+++ b/lib/rsa.js
@@ -1,8 +1,10 @@
 'use strict'
 
 var fs = require('fs')
+var path = require('path')
+
 var NodeRSA = require('node-rsa')
 
-var pem = fs.readFileSync('./keys/airport_rsa')
+var pem = fs.readFileSync(path.join(__dirname, '../keys/airport_rsa'))
 
 module.exports = new NodeRSA(pem)


### PR DESCRIPTION
Upon installing this I wasn't able to run:

```
❯ raop-rtsp-server --stdout | sox -traw -L -c2 -r44100 -b16 -e signed-integer - -tcoreaudio

-: (raw)

 File Size: 0
  Encoding: Signed PCM
  Channels: 2 @ 16-bit
Samplerate: 44100Hz
Replaygain: off
  Duration: unknown

In:0.00% 00:00:00.00 [00:00:00.00] Out:0     [      |      ]        Clip:0
fs.js:439
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^
Error: ENOENT, no such file or directory './keys/airport_rsa'
    at Object.fs.openSync (fs.js:439:18)
    at Object.fs.readFileSync (fs.js:290:15)
    at Object.<anonymous> (/Users/walter/.nvm/v0.10.40/lib/node_modules/raop-rtsp-server/lib/rsa.js:6:14)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/walter/.nvm/v0.10.40/lib/node_modules/raop-rtsp-server/lib/auth.js:6:11)
In:0.00% 00:00:00.00 [00:00:00.00] Out:0     [      |      ]        Clip:0
Done.
```
